### PR TITLE
chore: QWER 2026 신규 스케줄 추가

### DIFF
--- a/RockCrabCalendar/Modules/RockCrabDomain/Sources/RockCrabDomain/Models/QWERScheduleItem.swift
+++ b/RockCrabCalendar/Modules/RockCrabDomain/Sources/RockCrabDomain/Models/QWERScheduleItem.swift
@@ -906,5 +906,21 @@ extension QWERScheduleItem {
             members: [.Q, .W, .E, .R],
             category: .concert
         ),
+        QWERScheduleItem(
+            title: "체리 블라썸 뮤직 페스티벌",
+            date: simpleDateFormatter.date(from: "2026-04-05")!,
+            time: "14:00",
+            place: "진해공실운동장",
+            members: [.Q, .W, .E, .R],
+            category: .concert
+        ),
+        QWERScheduleItem(
+            title: "JJ50th Anniversary Fest 2026",
+            date: simpleDateFormatter.date(from: "2026-04-18")!,
+            time: "15:00",
+            place: "피아 아레나 MM",
+            members: [.Q, .W, .E, .R],
+            category: .concert
+        )
     ]
 }


### PR DESCRIPTION
## 변경 사항\n- QWER 일정 2건 추가\n  - 체리 블라썸 뮤직 페스티벌 (2026-04-05 14:00)\n  - JJ50th Anniversary Fest 2026 (2026-04-18 15:00)\n\n## 테스트\n- 별도 테스트 미실행 (데이터 상수 추가)