### PR TITLE
chore: 로컬 iOS 테스트 실행을 opt-in으로 전환

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ PROJECT ?= RockCrabCalendar.xcodeproj
 SCHEME ?= RockCrabCalendar
 DESTINATION ?= platform=iOS Simulator,name=iPhone 17,OS=latest
 APP_UNIT_TESTS_DIR ?= $(PROJECT_DIR)/RockCrabCalendarUnitTests
+RUN_IOS_TESTS ?= 0
 
 XCODEBUILD = xcodebuild -project $(PROJECT) -scheme $(SCHEME) -destination '$(DESTINATION)'
 
@@ -13,15 +14,16 @@ help:
 	@echo "  make open              # Open Xcode project"
 	@echo "  make build             # Build app scheme"
 	@echo "  make test-modules      # Run SPM module tests (Shared -> Domain -> Data)"
-	@echo "  make test-app          # Run app unit tests only"
+	@echo "  make test-app          # Run app unit tests only (CI or RUN_IOS_TESTS=1)"
 	@echo "  make test-unit         # Alias of test-app"
-	@echo "  make test-ui           # Run UI tests only"
+	@echo "  make test-ui           # Run UI tests only (CI or RUN_IOS_TESTS=1)"
 	@echo "  make test-all          # Run module tests + app unit + UI tests"
 	@echo "  make list-schemes      # List schemes"
 	@echo "  make list-destinations # Show available destinations"
 	@echo ""
 	@echo "Overrides:"
 	@echo "  DESTINATION='platform=iOS Simulator,name=iPhone 17,OS=latest'"
+	@echo "  RUN_IOS_TESTS=1        # Force iOS simulator tests locally"
 
 open:
 	cd $(PROJECT_DIR) && open $(PROJECT)
@@ -33,10 +35,14 @@ test-unit:
 	@$(MAKE) test-app
 
 test-app:
-	@if find $(APP_UNIT_TESTS_DIR) -type f -name '*Tests.swift' -print -quit 2>/dev/null | grep -q .; then \
-		cd $(PROJECT_DIR) && $(XCODEBUILD) -only-testing:RockCrabCalendarUnitTests test; \
+	@if [ "$$CI" = "true" ] || [ "$(RUN_IOS_TESTS)" = "1" ]; then \
+		if find $(APP_UNIT_TESTS_DIR) -type f -name '*Tests.swift' -print -quit 2>/dev/null | grep -q .; then \
+			cd $(PROJECT_DIR) && $(XCODEBUILD) -only-testing:RockCrabCalendarUnitTests test; \
+		else \
+			echo "No app-level unit tests found under $(APP_UNIT_TESTS_DIR). Skipping."; \
+		fi; \
 	else \
-		echo "No app-level unit tests found under $(APP_UNIT_TESTS_DIR). Skipping."; \
+		echo "Skipping app unit tests locally. Use RUN_IOS_TESTS=1 to run simulator tests."; \
 	fi
 
 test-module-shared:
@@ -51,7 +57,11 @@ test-module-data:
 test-modules: test-module-shared test-module-domain test-module-data
 
 test-ui:
-	cd $(PROJECT_DIR) && $(XCODEBUILD) -only-testing:RockCrabCalendarUITests test
+	@if [ "$$CI" = "true" ] || [ "$(RUN_IOS_TESTS)" = "1" ]; then \
+		cd $(PROJECT_DIR) && $(XCODEBUILD) -only-testing:RockCrabCalendarUITests test; \
+	else \
+		echo "Skipping UI tests locally. Use RUN_IOS_TESTS=1 to run simulator tests."; \
+	fi
 
 test-all:
 	@$(MAKE) test-modules


### PR DESCRIPTION
## 변경 배경
- 로컬에서 테스트 상태를 확인할 때마다 시뮬레이터가 자동 실행되어 개발 피드백 루프가 느려지는 문제가 있었습니다.

## 변경 내용
- `Makefile`에 `RUN_IOS_TESTS ?= 0` 기본값을 추가했습니다.
- `test-app`, `test-ui` 타깃은 아래 조건에서만 실행되도록 변경했습니다.
  - CI 환경(`CI=true`)
  - 로컬 강제 실행(`RUN_IOS_TESTS=1`)
- 기본 로컬 실행 시에는 시뮬레이터 테스트를 건너뛰고 안내 메시지를 출력합니다.
- `help` 문구에 동작 변경 및 강제 실행 방법을 반영했습니다.

## 기대 효과
- 로컬 개발 중 불필요한 시뮬레이터 부팅을 방지해 반복 작업 시간을 단축합니다.
- PR/메인 브랜치 CI 품질 게이트는 기존처럼 유지됩니다.

## 로컬 사용 예시
- 앱 단위 테스트 강제 실행: `make test-app RUN_IOS_TESTS=1`
- UI 테스트 강제 실행: `make test-ui RUN_IOS_TESTS=1`
