### PR TITLE
chore: PR-2 CI 게이트 강화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,23 +2,39 @@ name: CI
 
 on:
   pull_request:
-  push:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   module-tests:
-    name: Module Tests
+    name: ci / module-tests
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: macos-15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Test shared/domain/data modules
         run: make test-modules
 
   app-unit-tests:
-    name: App Unit Tests
+    name: ci / app-unit-tests
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: macos-15
     needs: module-tests
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Create CI Secrets.xcconfig

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ xcuserdata/
 # SwiftPM
 .swiftpm/
 .build/
+.xcode/
 
 # Logs
 *.log


### PR DESCRIPTION
## 작업 개요
PR-2 범위로 CI 게이트를 강화했습니다.
PR 기준 필수 검사를 안정적으로 강제하고, 중복 실행/장기 실행을 제어하는 데 초점을 맞췄습니다.

## 변경 사항
- CI 트리거 정리
  - `pull_request`를 `main` 대상으로 한정
  - 이벤트 타입을 `opened/synchronize/reopened/ready_for_review`로 명시
  - `push` 트리거 제거(게이트 목적에 맞춰 PR 중심 운용)
- 실행 안정성 강화
  - `concurrency` 추가로 동일 PR 중복 실행 자동 취소
  - job timeout 설정 (`module-tests: 20분`, `app-unit-tests: 30분`)
  - draft PR에서는 CI 생략하도록 조건 추가
- 체크 이름 고정
  - `ci / module-tests`
  - `ci / app-unit-tests`
  -> 브랜치 보호 규칙의 Required checks로 연결하기 쉬운 형태로 정리
- 개발 환경 정리
  - `.gitignore`에 `.xcode/` 추가 (로컬 캐시 노이즈 제거)

## 기대 효과
- PR 게이트 신뢰도 향상
- 불필요한 CI 소모 감소
- Required checks 설정/운영 단순화

## 참고
- Refs #13
