### PR TITLE
chore: v1.1.7 릴리즈 설정 반영

### DIFF
--- a/RockCrabCalendar/RockCrabCalendar.xcodeproj/project.pbxproj
+++ b/RockCrabCalendar/RockCrabCalendar.xcodeproj/project.pbxproj
@@ -1109,7 +1109,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				MARKETING_VERSION = 1.1.6;
+				MARKETING_VERSION = 1.1.7;
 				PRODUCT_BUNDLE_IDENTIFIER = ys.RockCrabCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -1153,7 +1153,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				MARKETING_VERSION = 1.1.6;
+				MARKETING_VERSION = 1.1.7;
 				PRODUCT_BUNDLE_IDENTIFIER = ys.RockCrabCalendar;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -1276,13 +1276,14 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.6;
+				MARKETING_VERSION = 1.1.7;
 				PRODUCT_BUNDLE_IDENTIFIER = ys.RockCrabCalendar.widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1305,13 +1306,14 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.6;
+				MARKETING_VERSION = 1.1.7;
 				PRODUCT_BUNDLE_IDENTIFIER = ys.RockCrabCalendar.widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "RELEASE $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;

--- a/RockCrabCalendar/RockCrabCalendar.xcodeproj/xcshareddata/xcschemes/RockCrabCalendar.xcscheme
+++ b/RockCrabCalendar/RockCrabCalendar.xcodeproj/xcshareddata/xcschemes/RockCrabCalendar.xcscheme
@@ -54,7 +54,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"


### PR DESCRIPTION
## 개요
v1.1.7 배포를 위한 릴리즈 설정 변경 PR입니다.

## 원인
- 신규 위젯/연동 기능 배포를 위해 앱 버전 상향이 필요했습니다.
- 아카이브/실배포 기준 실행 구성을 Release로 맞춰야 했습니다.

## 개선사항
- 앱/위젯 마케팅 버전 상향
  - `1.1.6 -> 1.1.7`
- 실행 스킴 기본 빌드 구성을 Release로 조정
  - `RockCrabCalendar.xcscheme` LaunchAction: `Debug -> Release`

## 개선방법
- `project.pbxproj`에서 App/Widget 타깃의 `MARKETING_VERSION`을 `1.1.7`로 통일 반영
- 공유 스킴 파일에서 런치 빌드 구성을 Release로 변경

## 체크리스트
- [x] 버전 상향 반영 확인
- [x] 릴리즈 브랜치 분리 및 커밋
- [ ] PR 머지 후 아카이브
- [ ] App Store Connect 업로드/검수 진행
