### PR TITLE
refactor: QWER 일정 추가 및 UI 버그 수정

### DIFF
--- a/RockCrabCalendar/Modules/RockCrabDomain/Sources/RockCrabDomain/Models/QWERMember.swift
+++ b/RockCrabCalendar/Modules/RockCrabDomain/Sources/RockCrabDomain/Models/QWERMember.swift
@@ -27,4 +27,21 @@ public enum QWERMember: String, CaseIterable, Codable {
             return AppLocalization.string("시연", value: "시연")
         }
     }
+
+    public var fixedOrder: Int {
+        switch self {
+        case .Q:
+            return 0
+        case .W:
+            return 1
+        case .E:
+            return 2
+        case .R:
+            return 3
+        }
+    }
+
+    public static func fixedSorted(_ members: [QWERMember]) -> [QWERMember] {
+        Array(Set(members)).sorted { $0.fixedOrder < $1.fixedOrder }
+    }
 }

--- a/RockCrabCalendar/Modules/RockCrabDomain/Sources/RockCrabDomain/Models/QWERScheduleItem.swift
+++ b/RockCrabCalendar/Modules/RockCrabDomain/Sources/RockCrabDomain/Models/QWERScheduleItem.swift
@@ -67,7 +67,7 @@ public struct QWERScheduleItem: SchedulableItemProtocol, Identifiable, Codable {
         self.timeStatus = timeStatus ?? .allDay
         self.place = place
         self.shouldNotify = shouldNotify
-        self.members = members
+        self.members = QWERMember.fixedSorted(members)
         self.category = category
 
         migrateLegacyTimeIfNeeded()
@@ -111,7 +111,7 @@ public struct QWERScheduleItem: SchedulableItemProtocol, Identifiable, Codable {
         self.shouldNotify = (try? container.decode(Bool.self, forKey: .shouldNotify)) ?? false
 
         let rawMembers = (try? container.decode([String].self, forKey: .members)) ?? []
-        self.members = rawMembers.compactMap { QWERMember(rawValue: $0) }
+        self.members = QWERMember.fixedSorted(rawMembers.compactMap { QWERMember(rawValue: $0) })
         self.category = ScheduleCategory(rawValue: (try? container.decode(String.self, forKey: .category)) ?? "") ?? .other
 
         migrateLegacyTimeIfNeeded()
@@ -590,7 +590,7 @@ extension QWERScheduleItem {
             category: .concert
         ),
         QWERScheduleItem(
-            title: "WORLD TOUR ROCKNATION SEOUL",
+            title: "WORLD TOUR ROCKATION SEOUL",
             date: simpleDateFormatter.date(from: "2025-10-03")!,
             time: "17:00",
             isAllDay: false,
@@ -600,7 +600,7 @@ extension QWERScheduleItem {
             category: .concert
         ),
         QWERScheduleItem(
-            title: "WORLD TOUR ROCKNATION SEOUL",
+            title: "WORLD TOUR ROCKATION SEOUL",
             date: simpleDateFormatter.date(from: "2025-10-04")!,
             time: "17:00",
             isAllDay: false,
@@ -610,7 +610,7 @@ extension QWERScheduleItem {
             category: .concert
         ),
         QWERScheduleItem(
-            title: "WORLD TOUR ROCKNATION SEOUL",
+            title: "WORLD TOUR ROCKATION SEOUL",
             date: simpleDateFormatter.date(from: "2025-10-05")!,
             time: "17:00",
             isAllDay: false,
@@ -968,10 +968,18 @@ extension QWERScheduleItem {
             category: .concert
         ),
         QWERScheduleItem(
+            title: "아주대학교 A-LOG",
+            date: simpleDateFormatter.date(from: "2026-04-03")!,
+            time: "17:30",
+            place: "아주대학교 노천극장",
+            members: [.Q, .W, .E, .R],
+            category: .concert
+        ),
+        QWERScheduleItem(
             title: "체리 블라썸 뮤직 페스티벌",
             date: simpleDateFormatter.date(from: "2026-04-05")!,
             time: "14:00",
-            place: "진해공실운동장",
+            place: "진해공설운동장",
             members: [.Q, .W, .E, .R],
             category: .concert
         ),
@@ -992,10 +1000,34 @@ extension QWERScheduleItem {
             category: .concert
         ),
         QWERScheduleItem(
+            title: "포스코 노동조합 K-노사문화 콘서트",
+            date: simpleDateFormatter.date(from: "2026-05-14")!,
+            time: "",
+            place: "포항 종합운동장",
+            members: [.Q, .W, .E, .R],
+            category: .concert
+        ),
+        QWERScheduleItem(
+            title: "YOUTH WAVE: THE BAND NIGHT",
+            date: simpleDateFormatter.date(from: "2026-05-16")!,
+            time: "14:00 ~ 19:00",
+            place: "경희대학교 국제캠퍼스(수원) 신승관",
+            members: [.Q, .W, .E, .R],
+            category: .concert
+        ),
+        QWERScheduleItem(
             title: "PEAK FESTIVAL 2026",
             date: simpleDateFormatter.date(from: "2026-05-23")!,
             time: "",
             place: "난지 한강공원",
+            members: [.Q, .W, .E, .R],
+            category: .concert
+        ),
+        QWERScheduleItem(
+            title: "슈퍼레이스 x 서울파크뮤직페스티벌",
+            date: simpleDateFormatter.date(from: "2026-05-24")!,
+            time: "",
+            place: "영암 국제 자동차 경주장",
             members: [.Q, .W, .E, .R],
             category: .concert
         ),

--- a/RockCrabCalendar/Modules/RockCrabDomain/Tests/RockCrabDomainTests/QWERScheduleItemMemberOrderTests.swift
+++ b/RockCrabCalendar/Modules/RockCrabDomain/Tests/RockCrabDomainTests/QWERScheduleItemMemberOrderTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import RockCrabDomain
+
+final class QWERScheduleItemMemberOrderTests: XCTestCase {
+    func testInitNormalizesMembersToFixedOrder() {
+        let item = QWERScheduleItem(
+            title: "테스트",
+            date: QWERScheduleItem.simpleDateFormatter.date(from: "2026-03-31")!,
+            place: "",
+            members: [.R, .E, .Q, .W],
+            category: .other
+        )
+
+        XCTAssertEqual(item.members, [.Q, .W, .E, .R])
+    }
+
+    func testDecodeNormalizesMembersToFixedOrder() throws {
+        let data = """
+        {
+          "id": "B56172ED-37CE-43A5-9A13-11B8545832D3",
+          "title": "테스트",
+          "date": 764035200,
+          "time": "",
+          "isAllDay": true,
+          "timeStatus": "allDay",
+          "place": "",
+          "shouldNotify": false,
+          "members": ["R", "Q", "E", "W"],
+          "category": "기타"
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(QWERScheduleItem.self, from: data)
+
+        XCTAssertEqual(decoded.members, [.Q, .W, .E, .R])
+    }
+}

--- a/RockCrabCalendar/RockCrabCalendar/Presentation/Features/Home/Components/HomeCalendarOptionView.swift
+++ b/RockCrabCalendar/RockCrabCalendar/Presentation/Features/Home/Components/HomeCalendarOptionView.swift
@@ -12,19 +12,22 @@ struct HomeCalendarOptionView: View {
     let onShowFilter: () -> Void
     let onToday: () -> Void
     let onToggleView: () -> Void
-    let onRefresh: () -> Void
 
     var body: some View {
-        HStack {
-            Button(action: onShowFilter) {
-                Label("필터", systemImage: "line.3.horizontal.decrease.circle")
-                    .labelStyle(.titleAndIcon)
-                    .pretendSemiBold(size: 14)
-                    .padding(EdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12))
-                    .background(Capsule().fill(Color.pillBackground))
-                    .foregroundColor(.primary)
+        HStack(spacing: 0) {
+            HStack {
+                Button(action: onShowFilter) {
+                    Label("필터", systemImage: "line.3.horizontal.decrease.circle")
+                        .labelStyle(.titleAndIcon)
+                        .pretendSemiBold(size: 14)
+                        .padding(EdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12))
+                        .background(Capsule().fill(Color.pillBackground))
+                        .foregroundColor(.primary)
+                }
+                Spacer()
             }
-            Spacer()
+            .frame(maxWidth: .infinity)
+
             Button(action: onToday) {
                 Text("오늘")
                     .pretendSemiBold(size: 14)
@@ -33,24 +36,18 @@ struct HomeCalendarOptionView: View {
                     .foregroundColor(.primary)
             }
 
-            Spacer()
-
-            Button(action: onToggleView) {
-                Image(systemName: viewType == .calendar ? "list.bullet" : "calendar")
+            HStack {
+                Spacer()
+                Button(action: onToggleView) {
+                    Image(systemName: viewType == .calendar ? "list.bullet" : "calendar")
+                }
+                .pretendSemiBold(size: 14)
+                .padding(6)
+                .animation(.easeInOut(duration: 0.25), value: viewType)
+                .background(Capsule().fill(Color.pillBackground))
+                .foregroundColor(.primary)
             }
-            .pretendSemiBold(size: 14)
-            .padding(6)
-            .animation(.easeInOut(duration: 0.25), value: viewType)
-            .background(Capsule().fill(Color.pillBackground))
-            .foregroundColor(.primary)
-
-            Button(action: onRefresh) {
-                Image(systemName: "arrow.circlepath")
-                    .pretendSemiBold(size: 14)
-                    .padding(6)
-                    .background(Capsule().fill(Color.pillBackground))
-                    .foregroundColor(.primary)
-            }
+            .frame(maxWidth: .infinity)
         }
         .padding(.horizontal, 12)
     }

--- a/RockCrabCalendar/RockCrabCalendar/Presentation/Features/Home/HomeMainView.swift
+++ b/RockCrabCalendar/RockCrabCalendar/Presentation/Features/Home/HomeMainView.swift
@@ -69,10 +69,6 @@ struct HomeMainView: View {
                         },
                         onToggleView: {
                             viewType = (viewType == .calendar) ? .list : .calendar
-                        },
-                        onRefresh: {
-                            scheduleVM.loadCachedAndLocalSchedules()
-                            userVM.fetchAllSchedules()
                         }
                     )
                     

--- a/RockCrabCalendar/RockCrabCalendar/Presentation/Features/Home/Schedule/ViewModel/ScheduleEditFormState.swift
+++ b/RockCrabCalendar/RockCrabCalendar/Presentation/Features/Home/Schedule/ViewModel/ScheduleEditFormState.swift
@@ -108,7 +108,7 @@ struct ScheduleEditFormState {
             timeStatus: qwerTimeStatus,
             place: trimmed(place),
             shouldNotify: qwerTimeStatus == .timed ? shouldNotify : false,
-            members: Array(selectedMembers).sorted { $0.rawValue < $1.rawValue },
+            members: QWERMember.fixedSorted(Array(selectedMembers)),
             category: category
         )
     }


### PR DESCRIPTION
## 요약
- QWER 일정 데이터와 표기를 최신 상태로 정리했습니다.
- QWER 멤버 노출 순서를 항상 쵸단, 마젠타, 히나, 시연 순으로 고정했습니다.
- 홈 상단 옵션에서 중복된 새로고침 버튼을 제거하고 오늘 버튼 정렬을 중앙 기준으로 조정했습니다.

## 상세 변경
- QWER 일정 문구 오타와 장소명을 수정하고 신규 일정을 추가
- QWERScheduleItem 생성/디코드/수정 경로에서 멤버 순서를 고정 순서로 정규화
- 멤버 순서 회귀 방지 테스트 추가
- HomeCalendarOptionView의 새로고침 버튼 제거
- HomeCalendarOptionView 레이아웃을 조정해 오늘 버튼이 시각적으로 중앙에 오도록 수정

## 테스트
- `make test-app` 실행
- `make test-modules` 실행 시도
  - SwiftPM 캐시 경로 권한 제한으로 샌드박스에서 실패
