### PR TITLE
chore: ignore marketing node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ xcuserdata/
 # Logs
 *.log
 
+# Marketing
+marketing/node_modules/
+
 # 기타 민감정보
 *.env
 


### PR DESCRIPTION
## 요약
- `marketing/node_modules`가 워크트리에 다시 잡히지 않도록 `.gitignore`를 정리했습니다.

## 상세 변경
- `.gitignore`에 `marketing/node_modules/` 규칙 추가

## 테스트
- `git status`로 `marketing/node_modules/`가 미추적으로 노출되지 않는지 확인
