### PR TITLE
feat: Firebase Analytics 상세 추적 추가

### DIFF
--- a/RockCrabCalendar/RockCrabCalendar/Presentation/App/RockCrabCalendarApp.swift
+++ b/RockCrabCalendar/RockCrabCalendar/Presentation/App/RockCrabCalendarApp.swift
@@ -84,6 +84,15 @@ struct RockCrabCalendarApp: App {
                     WidgetCenter.shared.reloadAllTimelines()
                 }
             }
+            .onChange(of: selectedTab) { _, newValue in
+                AnalyticsHelper.logAction(
+                    actionName: "tab_selected",
+                    label: "탭 선택",
+                    parameters: [
+                        "tab_name": tabLabel(for: newValue)
+                    ]
+                )
+            }
             .alert(updatePromptTitle, isPresented: isShowingUpdatePrompt) {
                 Button(updateLaterTitle, role: .cancel) {
                     guard let prompt = appUpdatePrompt else { return }
@@ -174,6 +183,17 @@ struct RockCrabCalendarApp: App {
 
     private var updateNowTitle: String {
         AppLocalization.localized(ko: "업데이트", en: "Update")
+    }
+
+    private func tabLabel(for tab: AppTab) -> String {
+        switch tab {
+        case .home:
+            return "홈"
+        case .record:
+            return "기록"
+        case .settings:
+            return "설정"
+        }
     }
 
     private func handleDeepLink(_ url: URL) {
@@ -295,11 +315,7 @@ private struct TabBarAppearanceConfigurator: TabBarAppearanceConfiguring {
     @MainActor
     func configure() {
         let appearance = UITabBarAppearance()
-        appearance.configureWithOpaqueBackground()
-        appearance.backgroundColor = UIColor { trait in
-            trait.userInterfaceStyle == .dark ? .secondarySystemBackground : .white
-        }
-        appearance.shadowColor = .clear
+        appearance.configureWithDefaultBackground()
 
         [appearance.stackedLayoutAppearance, appearance.inlineLayoutAppearance, appearance.compactInlineLayoutAppearance]
             .forEach { itemAppearance in
@@ -314,7 +330,6 @@ private struct TabBarAppearanceConfigurator: TabBarAppearanceConfiguring {
         tabBar.scrollEdgeAppearance = appearance
         tabBar.tintColor = .label
         tabBar.unselectedItemTintColor = .secondaryLabel
-        tabBar.isTranslucent = false
     }
 }
 

--- a/RockCrabCalendar/RockCrabCalendar/Presentation/Features/Home/HomeMainView.swift
+++ b/RockCrabCalendar/RockCrabCalendar/Presentation/Features/Home/HomeMainView.swift
@@ -67,6 +67,10 @@ struct HomeMainView: View {
                     HomeCalendarOptionView(
                         viewType: viewType,
                         onShowFilter: {
+                            AnalyticsHelper.logAction(
+                                actionName: "home_filter_open",
+                                label: "홈 필터 열기"
+                            )
                             showCategorySheet = true
                         },
                         onToday: {
@@ -74,6 +78,10 @@ struct HomeMainView: View {
                             calendarVM.select(date: today)
                             calendarVM.currentMonth = calendarVM.startOfMonth(for: today)
                             scheduleVM.selectedDate = today
+                            AnalyticsHelper.logAction(
+                                actionName: "home_today_tap",
+                                label: "오늘 버튼 선택"
+                            )
                         },
                         onSearch: {
                             withAnimation(.easeInOut(duration: 0.2)) {
@@ -88,6 +96,13 @@ struct HomeMainView: View {
                             if !isSearchExpanded {
                                 searchText = ""
                             }
+                            AnalyticsHelper.logAction(
+                                actionName: "schedule_search_toggle",
+                                label: isSearchExpanded ? "검색 열기" : "검색 닫기",
+                                parameters: [
+                                    "view_type": viewType.analyticsLabel
+                                ]
+                            )
                         },
                         onToggleView: {
                             viewType = (viewType == .calendar) ? .list : .calendar
@@ -95,6 +110,13 @@ struct HomeMainView: View {
                                 isSearchExpanded = false
                                 searchText = ""
                             }
+                            AnalyticsHelper.logAction(
+                                actionName: "home_view_type_change",
+                                label: "홈 보기 방식 변경",
+                                parameters: [
+                                    "view_type": viewType.analyticsLabel
+                                ]
+                            )
                         }
                     )
 
@@ -110,9 +132,11 @@ struct HomeMainView: View {
                             scheduleVM: scheduleVM,
                             userVM: userVM,
                             onEdit: { mode in
+                                logScheduleEditOpen(mode)
                                 navigationPath.append(.editSchedule(mode: mode))
                             },
                             onRecord: { target in
+                                logRecordEditOpen(target)
                                 navigationPath.append(.editRecord(target: target))
                             }
                         )
@@ -123,9 +147,11 @@ struct HomeMainView: View {
                             userVM: userVM,
                             searchText: searchText,
                             onEdit: { mode in
+                                logScheduleEditOpen(mode)
                                 navigationPath.append(.editSchedule(mode: mode))
                             },
                             onRecord: { target in
+                                logRecordEditOpen(target)
                                 navigationPath.append(.editRecord(target: target))
                             }
                         )
@@ -144,10 +170,20 @@ struct HomeMainView: View {
                     isExpanded: $isFabExpanded,
                     onAddQWER: {
                         showCategorySheet = false
+                        AnalyticsHelper.logAction(
+                            actionName: "schedule_create_open",
+                            label: "QWER 일정 추가 열기",
+                            parameters: ["schedule_kind": "QWER"]
+                        )
                         navigationPath.append(.addSchedule(kind: .qwer))
                     },
                     onAddUser: {
                         showCategorySheet = false
+                        AnalyticsHelper.logAction(
+                            actionName: "schedule_create_open",
+                            label: "개인 일정 추가 열기",
+                            parameters: ["schedule_kind": "개인"]
+                        )
                         navigationPath.append(.addSchedule(kind: .user))
                     }
                 )
@@ -205,13 +241,28 @@ struct HomeMainView: View {
             scheduleVM.selectedDate = calendarVM.selectedDate
             scheduleVM.loadCachedAndLocalSchedules()
             userVM.fetchAllSchedules()
-            AnalyticsHelper.logEvent(eventName: "main_screen", parameters: ["label":"메인화면"])
+            AnalyticsHelper.logScreen(
+                screenName: "home",
+                label: "홈 화면",
+                parameters: [
+                    "selected_view": viewType.analyticsLabel,
+                    "qwer_schedule_count": scheduleVM.schedules.count,
+                    "user_schedule_count": userVM.schedules.count
+                ]
+            )
         }
         .sheet(isPresented: $showCategorySheet) {
             CategoryFilterSheet(
                 active: scheduleVM.activeCategories,
                 onApply: { selected in
                     scheduleVM.setCategories(selected)
+                    AnalyticsHelper.logAction(
+                        actionName: "home_filter_apply",
+                        label: "홈 필터 적용",
+                        parameters: [
+                            "selected_category_count": selected.count
+                        ]
+                    )
                 }
             )
             .presentationDragIndicator(.visible)
@@ -234,6 +285,31 @@ struct HomeMainView: View {
 
 }
 
+private extension HomeMainView {
+    func logScheduleEditOpen(_ mode: ScheduleEditMode) {
+        AnalyticsHelper.logAction(
+            actionName: "schedule_edit_open",
+            label: "일정 수정 열기",
+            parameters: [
+                "schedule_kind": mode.kind.analyticsLabel,
+                "edit_mode": mode.analyticsModeLabel,
+                "source_view": viewType.analyticsLabel
+            ]
+        )
+    }
+
+    func logRecordEditOpen(_ target: ScheduleRecordTarget) {
+        AnalyticsHelper.logAction(
+            actionName: "record_edit_open",
+            label: "일정 기록 열기",
+            parameters: [
+                "schedule_kind": target.kind.analyticsLabel,
+                "source_view": viewType.analyticsLabel
+            ]
+        )
+    }
+}
+
 extension HomeMainView {
     private enum HomeRoute: Hashable {
         case addSchedule(kind: ScheduleEditKind)
@@ -246,5 +322,14 @@ extension HomeMainView {
         case calendar
         /// 리스트
         case list
+
+        var analyticsLabel: String {
+            switch self {
+            case .calendar:
+                return "캘린더"
+            case .list:
+                return "리스트"
+            }
+        }
     }
 }

--- a/RockCrabCalendar/RockCrabCalendar/Presentation/Features/Home/Schedule/View/ScheduleEditView.swift
+++ b/RockCrabCalendar/RockCrabCalendar/Presentation/Features/Home/Schedule/View/ScheduleEditView.swift
@@ -98,7 +98,27 @@ struct ScheduleEditView: View {
             await viewModel.refreshLocalFlagIfNeeded()
         }
         .onAppear {
-            AnalyticsHelper.logEvent(eventName: "schedule_edit_screen", parameters: ["label":"일정수정화면"])
+            AnalyticsHelper.logScreen(
+                screenName: "schedule_edit",
+                label: viewModel.mode.analyticsModeLabel == "추가" ? "일정 추가 화면" : "일정 수정 화면",
+                parameters: scheduleAnalyticsParameters()
+            )
+        }
+        .onChange(of: viewModel.form.shouldNotify) { _, isEnabled in
+            AnalyticsHelper.logAction(
+                actionName: "notification_toggle",
+                label: isEnabled ? "일정 알림 켜기" : "일정 알림 끄기",
+                parameters: scheduleAnalyticsParameters()
+            )
+        }
+        .onChange(of: viewModel.form.notificationLeadTime) { _, leadTime in
+            AnalyticsHelper.logAction(
+                actionName: "notification_lead_change",
+                label: "일정 알림 시간 변경",
+                parameters: scheduleAnalyticsParameters().merging([
+                    "notification_lead_time": leadTime.displayText
+                ]) { _, new in new }
+            )
         }
     }
 }
@@ -107,6 +127,13 @@ struct ScheduleEditView: View {
 private extension ScheduleEditView {
     func save() {
         let feedback = viewModel.save()
+        AnalyticsHelper.logAction(
+            actionName: "schedule_save",
+            label: feedback == .none ? "일정 저장 성공" : "일정 저장 알림 경고",
+            parameters: scheduleAnalyticsParameters().merging([
+                "save_result": feedback == .none ? "성공" : "알림 경고"
+            ]) { _, new in new }
+        )
 
         if feedback == .none {
             dismiss()
@@ -115,7 +142,18 @@ private extension ScheduleEditView {
     
     func deleteItem() {
         if viewModel.deleteButtonTapped() {
+            AnalyticsHelper.logAction(
+                actionName: "schedule_delete",
+                label: "일정 삭제 성공",
+                parameters: scheduleAnalyticsParameters()
+            )
             dismiss()
+        } else {
+            AnalyticsHelper.logAction(
+                actionName: "schedule_delete_blocked",
+                label: "일정 삭제 차단",
+                parameters: scheduleAnalyticsParameters()
+            )
         }
     }
 
@@ -142,5 +180,34 @@ private extension ScheduleEditView {
     func defaultEndTime() -> Date {
         let start = defaultStartTime()
         return Calendar.current.date(byAdding: .hour, value: 1, to: start) ?? start
+    }
+
+    func scheduleAnalyticsParameters() -> [String: Any] {
+        [
+            "schedule_kind": viewModel.kind.analyticsLabel,
+            "edit_mode": viewModel.mode.analyticsModeLabel,
+            "time_type": timeTypeLabel,
+            "notification_enabled": viewModel.form.shouldNotify ? 1 : 0,
+            "notification_lead_time": viewModel.form.shouldNotify
+                ? viewModel.form.notificationLeadTime.displayText
+                : "사용 안 함",
+            "has_place": viewModel.form.place.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? 0 : 1
+        ]
+    }
+
+    var timeTypeLabel: String {
+        switch viewModel.kind {
+        case .qwer:
+            switch viewModel.form.qwerTimeStatus {
+            case .allDay:
+                return "하루종일"
+            case .timed:
+                return "시간 있음"
+            case .unspecified:
+                return "시간 미정"
+            }
+        case .user:
+            return viewModel.form.isAllDay ? "하루종일" : "시간 있음"
+        }
     }
 }

--- a/RockCrabCalendar/RockCrabCalendar/Presentation/Features/Record/View/ScheduleRecordEditView.swift
+++ b/RockCrabCalendar/RockCrabCalendar/Presentation/Features/Record/View/ScheduleRecordEditView.swift
@@ -74,8 +74,19 @@ struct ScheduleRecordEditView: View {
             ToolbarItem(placement: .topBarTrailing) {
                 Button("저장") {
                     if viewModel.save() {
+                        AnalyticsHelper.logAction(
+                            actionName: "record_save",
+                            label: viewModel.isEditing ? "기록 수정 저장" : "기록 신규 저장",
+                            parameters: recordAnalyticsParameters()
+                        )
                         onRecordChanged()
                         dismiss()
+                    } else {
+                        AnalyticsHelper.logAction(
+                            actionName: "record_save_failed",
+                            label: "기록 저장 실패",
+                            parameters: recordAnalyticsParameters()
+                        )
                     }
                 }
                 .fontWeight(.semibold)
@@ -90,8 +101,19 @@ struct ScheduleRecordEditView: View {
         .alert("기록을 삭제할까요?", isPresented: $isShowingDeleteConfirm) {
             Button("삭제", role: .destructive) {
                 if viewModel.deleteRecord() {
+                    AnalyticsHelper.logAction(
+                        actionName: "record_delete",
+                        label: "기록 삭제 성공",
+                        parameters: recordAnalyticsParameters()
+                    )
                     onRecordChanged()
                     dismiss()
+                } else {
+                    AnalyticsHelper.logAction(
+                        actionName: "record_delete_failed",
+                        label: "기록 삭제 실패",
+                        parameters: recordAnalyticsParameters()
+                    )
                 }
             }
             Button("취소", role: .cancel) { }
@@ -110,6 +132,13 @@ struct ScheduleRecordEditView: View {
             Task {
                 await handleSelectedPhotoItems(newItems)
             }
+        }
+        .onAppear {
+            AnalyticsHelper.logScreen(
+                screenName: "record_edit",
+                label: viewModel.isEditing ? "기록 수정 화면" : "기록 작성 화면",
+                parameters: recordAnalyticsParameters()
+            )
         }
         .onDisappear {
             guard previewPhoto == nil, isShowingEmojiPicker == false else { return }
@@ -278,6 +307,11 @@ struct ScheduleRecordEditView: View {
                         Button {
                             viewModel.form.emoji = emoji
                             isShowingEmojiPicker = false
+                            AnalyticsHelper.logAction(
+                                actionName: "record_emoji_select",
+                                label: "기록 이모지 선택",
+                                parameters: recordAnalyticsParameters()
+                            )
                         } label: {
                             Text(verbatim: emoji)
                                 .font(.system(size: 30))
@@ -391,6 +425,11 @@ struct ScheduleRecordEditView: View {
                 withAnimation(.snappy(duration: 0.22)) {
                     viewModel.removePhoto(id: photo.id)
                 }
+                AnalyticsHelper.logAction(
+                    actionName: "record_photo_remove",
+                    label: "기록 사진 삭제",
+                    parameters: recordAnalyticsParameters()
+                )
             } label: {
                 Image(systemName: "xmark.circle.fill")
                     .font(.title3)
@@ -428,6 +467,11 @@ struct ScheduleRecordEditView: View {
         guard let data = viewModel.imageData(for: photo),
               let image = UIImage(data: data) else { return }
         previewPhoto = RecordPhotoPreview(id: photo.id, image: image)
+        AnalyticsHelper.logAction(
+            actionName: "record_photo_preview",
+            label: "기록 사진 크게 보기",
+            parameters: recordAnalyticsParameters()
+        )
     }
 
     @MainActor
@@ -442,9 +486,26 @@ struct ScheduleRecordEditView: View {
 
         for item in items.prefix(maxSelectablePhotoCount) {
             if let data = try? await item.loadTransferable(type: Data.self) {
+                let previousCount = viewModel.photos.count
                 viewModel.addPhoto(data: data)
+                if viewModel.photos.count > previousCount {
+                    AnalyticsHelper.logAction(
+                        actionName: "record_photo_add",
+                        label: "기록 사진 추가",
+                        parameters: recordAnalyticsParameters()
+                    )
+                }
             }
         }
+    }
+
+    private func recordAnalyticsParameters() -> [String: Any] {
+        [
+            "schedule_kind": viewModel.target.kind.analyticsLabel,
+            "edit_mode": viewModel.isEditing ? "수정" : "추가",
+            "photo_count": viewModel.photos.count,
+            "has_body": viewModel.form.trimmedBody.isEmpty ? 0 : 1
+        ]
     }
 }
 

--- a/RockCrabCalendar/RockCrabCalendar/Presentation/Features/Record/View/ScheduleRecordListView.swift
+++ b/RockCrabCalendar/RockCrabCalendar/Presentation/Features/Record/View/ScheduleRecordListView.swift
@@ -47,6 +47,19 @@ struct ScheduleRecordListView: View {
                                                 ScheduleRecordCard(record: record)
                                             }
                                             .buttonStyle(.plain)
+                                            .simultaneousGesture(
+                                                TapGesture().onEnded {
+                                                    AnalyticsHelper.logAction(
+                                                        actionName: "record_card_tap",
+                                                        label: "기록 카드 선택",
+                                                        parameters: [
+                                                            "schedule_kind": record.linkedSchedule.kind.analyticsLabel,
+                                                            "photo_count": record.photos.count,
+                                                            "has_body": record.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? 0 : 1
+                                                        ]
+                                                    )
+                                                }
+                                            )
                                         }
                                     }
                                     .padding(.horizontal, 16)
@@ -76,6 +89,14 @@ struct ScheduleRecordListView: View {
         }
         .onAppear {
             viewModel.loadRecords()
+            AnalyticsHelper.logScreen(
+                screenName: "record_list",
+                label: "기록 탭",
+                parameters: [
+                    "record_count": viewModel.records.count,
+                    "is_empty": viewModel.records.isEmpty ? 1 : 0
+                ]
+            )
         }
     }
 

--- a/RockCrabCalendar/RockCrabCalendar/Presentation/Utils/AnalyticsHelper.swift
+++ b/RockCrabCalendar/RockCrabCalendar/Presentation/Utils/AnalyticsHelper.swift
@@ -7,11 +7,72 @@
 
 import FirebaseAnalytics
 import Foundation
+import RockCrabDomain
 
 struct AnalyticsHelper {
     static func logEvent(eventName: String, parameters: [String: Any]) {
         #if RELEASE
         Analytics.logEvent(eventName, parameters: parameters)
         #endif
+    }
+
+    static func logScreen(
+        screenName: String,
+        label: String,
+        parameters: [String: Any] = [:]
+    ) {
+        logEvent(
+            eventName: "screen_view_detail",
+            parameters: parameters.merging([
+                "screen_name": screenName,
+                "label": label
+            ]) { _, new in new }
+        )
+    }
+
+    static func logAction(
+        actionName: String,
+        label: String,
+        parameters: [String: Any] = [:]
+    ) {
+        logEvent(
+            eventName: actionName,
+            parameters: parameters.merging([
+                "label": label
+            ]) { _, new in new }
+        )
+    }
+}
+
+extension ScheduleEditKind {
+    var analyticsLabel: String {
+        switch self {
+        case .qwer:
+            return "QWER"
+        case .user:
+            return "개인"
+        }
+    }
+}
+
+extension ScheduleEditMode {
+    var analyticsModeLabel: String {
+        switch self {
+        case .create:
+            return "추가"
+        case .editQWER, .editUser:
+            return "수정"
+        }
+    }
+}
+
+extension ScheduleRecord.LinkedScheduleKind {
+    var analyticsLabel: String {
+        switch self {
+        case .qwer:
+            return "QWER"
+        case .user:
+            return "개인"
+        }
     }
 }


### PR DESCRIPTION
## 요약
- 탭 선택, 홈 화면 주요 액션, 일정 저장/삭제, 알림 설정 변경 이벤트를 Firebase Analytics에 추가했습니다.
- 기록 탭 진입, 기록 카드 선택, 기록 저장/삭제, 이모지/사진 액션 추적을 추가했습니다.
- 이벤트명은 Firebase 호환성을 위해 영문 스네이크 케이스로 유지하고, label/상세 파라미터는 한글 값으로 기록합니다.

## 테스트
- git diff --check 확인
- 빌드 및 UI 확인은 사용자가 직접 진행 예정