### PR TITLE
chore: 로컬 macOS 파일 ignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ Config/Secrets.xcconfig
 **/Config/*.xcconfig
 
 # Xcode
+.DS_Store
+**/.DS_Store
 DerivedData/
 build/
 *.xcworkspace


### PR DESCRIPTION
## 요약
- .DS_Store 파일이 저장소 변경사항에 잡히지 않도록 .gitignore 규칙을 추가했습니다.
- 로컬에서 재생성 가능한 캐시(.xcode, module .build, marketing/node_modules)와 .DS_Store 파일을 정리했습니다.

## 확인
- git diff --check 통과
- 로컬 캐시 정리 후 불필요한 .DS_Store/.build/DerivedData/node_modules 잔여 항목 없음